### PR TITLE
Feature/add list partic #1

### DIFF
--- a/__tests__/components/HikeComponent.test.jsx
+++ b/__tests__/components/HikeComponent.test.jsx
@@ -3,14 +3,23 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRouter } from "next/navigation";
 import { useGlobal } from "@/app/context/GlobalContext";
+import { useModal } from "@/app/context/ModalContext";
 import {
   fetchTrailById,
   fetchUserById,
+  fetchParticipantsByHike,
   addParticipant,
   removeParticipant,
 } from "@/app/api/data/data";
 import { convertDate, convertTime } from "@/app/lib/utils";
-import { MOCK_HIKE, MOCK_USER, MOCK_TRAIL_INFO } from "@/app/lib/constants";
+import {
+  MOCK_HIKE,
+  MOCK_USER,
+  MOCK_TRAIL_INFO,
+  MOCK_PARTY_MBR,
+  MOCK_PARTY_TBL,
+  MOCK_NAMES_AVATARS
+} from "@/app/lib/constants";
 import HikeComponent from "@/app/ui/components/HikeComponent";
 
 jest.mock("next/navigation", () => ({
@@ -21,6 +30,10 @@ jest.mock("@/app/context/GlobalContext", () => ({
   useGlobal: jest.fn(),
 }));
 
+jest.mock("@/app/context/ModalContext", () => ({
+  useModal: jest.fn(),
+}));
+
 jest.mock("@/app/lib/utils", () => ({
   convertDate: jest.fn(),
   convertTime: jest.fn(),
@@ -29,12 +42,13 @@ jest.mock("@/app/lib/utils", () => ({
 jest.mock("@/app/api/data/data", () => ({
   fetchTrailById: jest.fn(),
   fetchUserById: jest.fn(),
+  fetchParticipantsByHike: jest.fn(),
   addParticipant: jest.fn(),
   removeParticipant: jest.fn(),
 }));
 
 describe("HikeComponent", () => {
-  let mockRouterPush, mockSetHike;
+  let mockRouterPush, mockSetHike, mockShowModal, mockCloseModal;
 
   beforeEach(() => {
     mockRouterPush = jest.fn();
@@ -42,6 +56,8 @@ describe("HikeComponent", () => {
 
     mockSetHike = jest.fn();
     mockSetTriggerRefresh = jest.fn();
+    mockShowModal = jest.fn();
+    mockCloseModal = jest.fn();
 
     useGlobal.mockReturnValue({
       currentUser: MOCK_USER,
@@ -49,11 +65,19 @@ describe("HikeComponent", () => {
       setTriggerRefresh: mockSetTriggerRefresh,
     });
 
+    useModal.mockReturnValue({
+      showModal: mockShowModal,
+      closeModal: mockCloseModal,
+    });
+
     convertDate.mockReturnValue("12/01/2024");
     convertTime.mockReturnValue("10:00 AM");
 
     fetchTrailById.mockResolvedValue([MOCK_TRAIL_INFO]);
-    fetchUserById.mockResolvedValue([MOCK_USER]);
+    fetchUserById.mockResolvedValueOnce([MOCK_USER])
+                  .mockResolvedValueOnce([MOCK_USER])
+                  .mockResolvedValueOnce([MOCK_PARTY_MBR]);
+    fetchParticipantsByHike.mockResolvedValue([MOCK_PARTY_TBL]);
   });
 
   afterEach(() => {
@@ -67,7 +91,12 @@ describe("HikeComponent", () => {
         expect(screen.getByText(/sunset hike/i)).toBeInTheDocument();
       });
       expect(fetchTrailById).toHaveBeenCalledWith(MOCK_HIKE.trail_id);
-      expect(fetchUserById).toHaveBeenCalledWith(MOCK_HIKE.creator_id);
+      expect(fetchUserById).toHaveBeenCalledTimes(3);
+      expect(fetchUserById).toHaveBeenCalledWith(...[
+        MOCK_HIKE.creator_id,
+        ...MOCK_PARTY_TBL.map(o => o.user_id)
+      ]);
+      expect(fetchParticipantsByHike).toHaveBeenCalledWith(MOCK_HIKE.id);
     });
   });
 
@@ -76,42 +105,84 @@ describe("HikeComponent", () => {
       render(<HikeComponent hikeType="new" hikeInfo={MOCK_HIKE} />);
       await waitFor(() => {
         expect(fetchTrailById).toHaveBeenCalledWith(MOCK_HIKE.trail_id);
-        expect(fetchUserById).toHaveBeenCalledWith(MOCK_HIKE.creator_id);
+        expect(fetchUserById).toHaveBeenCalledTimes(3);
+        expect(fetchUserById).toHaveBeenCalledWith(...[
+          MOCK_HIKE.creator_id,
+          ...MOCK_PARTY_TBL.map(o => o.user_id)
+        ]);
+        expect(fetchParticipantsByHike).toHaveBeenCalledWith(MOCK_HIKE.id);
         expect(convertDate).toHaveBeenCalledWith(MOCK_HIKE.date);
         expect(convertTime).toHaveBeenCalledWith(MOCK_HIKE.time);
       });
     });
 
-    it("adds participant when 'Join Hike' is clicked", async () => {
+    const ADDS = "adds participant when 'Join Hike' is clicked";
+    const REMOVES = "removes participant when 'Opt Out' is clicked";
+    const REDIRECTS = "removes participant when 'Opt Out' is clicked";
+    const AND_OVERLAYS = " opens a modal when '# participants' is clicked";
+    const partyCount = MOCK_PARTY_TBL.length;
+    const partyExp = new RegExp(partyCount + " " + "participant" + "s?");
+
+    it(ADDS + AND_OVERLAYS, async () => {
       render(<HikeComponent hikeType="available" hikeInfo={MOCK_HIKE} />);
       await waitFor(() => {
-        const button = screen.getByRole("button", { name: /join hike/i });
-        expect(button).toBeInTheDocument();
+        const button1 = screen.getByRole("button", { name: /join hike/i });
+        const button2 = screen.getByRole("button", { name: partyExp });
+        expect(button1).toBeInTheDocument();
+        expect(button2).toBeInTheDocument();
       });
-      const button = screen.getByRole("button", { name: /join hike/i });
-      await userEvent.click(button);
+      const button1 = screen.getByRole("button", { name: /join hike/i });
+      const button2 = screen.getByRole("button", { name: partyExp });
+      await userEvent.click(button1);
+      await userEvent.click(button2);
       expect(addParticipant).toHaveBeenCalledWith(MOCK_USER.id, MOCK_HIKE.id);
+      expect(mockShowModal).toHaveBeenCalledWith(...[
+        MOCK_HIKE.title,
+        MOCK_NAMES_AVATARS,
+        null,
+        mockCloseModal,
+      ]);
     });
 
-    it("removes participant when 'Opt Out' is clicked", async () => {
+    it(REMOVES + AND_OVERLAYS, async () => {
       render(<HikeComponent hikeType="joined" hikeInfo={MOCK_HIKE} />);
       await waitFor(() => {
-        const button = screen.getByRole("button", { name: /opt out/i });
-        expect(button).toBeInTheDocument();
+        const button1 = screen.getByRole("button", { name: /opt out/i });
+        const button2 = screen.getByRole("button", { name: partyExp });
+        expect(button1).toBeInTheDocument();
+        expect(button2).toBeInTheDocument();
       });
-      const button = screen.getByRole("button", { name: /opt out/i });
-      await userEvent.click(button);
+      const button1 = screen.getByRole("button", { name: /opt out/i });
+      const button2 = screen.getByRole("button", { name: partyExp });
+      await userEvent.click(button1);
+      await userEvent.click(button2);
       expect(removeParticipant).toHaveBeenCalledWith(MOCK_USER.id, MOCK_HIKE.id);
+      expect(mockShowModal).toHaveBeenCalledWith(...[
+        MOCK_HIKE.title,
+        MOCK_NAMES_AVATARS,
+        null,
+        mockCloseModal,
+      ]);
     });
     
-    it("redirects to edit-hike when 'Edit Hike' is clicked", async () => {
+    it(REDIRECTS + AND_OVERLAYS, async () => {
       render(<HikeComponent hikeType="created" hikeInfo={MOCK_HIKE} />);
       await waitFor(() => {
-        const button = screen.getByRole("button", { name: /edit hike/i });
-        expect(button).toBeInTheDocument();
+        const button1 = screen.getByRole("button", { name: /edit hike/i });
+        const button2 = screen.getByRole("button", { name: partyExp });
+        expect(button1).toBeInTheDocument();
+        expect(button2).toBeInTheDocument();
       });
-      const button = screen.getByRole("button", { name: /edit hike/i });
-      await userEvent.click(button);
+      const button1 = screen.getByRole("button", { name: /edit hike/i });
+      const button2 = screen.getByRole("button", { name: partyExp });
+      await userEvent.click(button2);
+      expect(mockShowModal).toHaveBeenCalledWith(...[
+        MOCK_HIKE.title,
+        MOCK_NAMES_AVATARS,
+        null,
+        mockCloseModal,
+      ]);
+      await userEvent.click(button1);
       expect(mockSetHike).toHaveBeenCalledWith(MOCK_HIKE.id);
       expect(mockRouterPush).toHaveBeenCalledWith("/edit-hike");
     });

--- a/__tests__/components/HikePost.test.jsx
+++ b/__tests__/components/HikePost.test.jsx
@@ -1,8 +1,15 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MOCK_HIKE_INFO, MOCK_TRAIL_INFO } from "@/app/lib/constants";
+import {
+  MOCK_HIKE_INFO,
+  MOCK_TRAIL_INFO,
+  MOCK_PARTY_TBL
+} from "@/app/lib/constants";
 import HikePost from "@/app/ui/components/HikePost";
+
+const partyCount = MOCK_PARTY_TBL.length;
+const partyExp = new RegExp(partyCount + " " + "participant" + "s?");
 
 describe("HikePost", () => {
   describe("rendering", () => {
@@ -16,6 +23,7 @@ describe("HikePost", () => {
     render(<HikePost hikeInfo={MOCK_HIKE_INFO} />);
     expect(screen.getByText("Sunset Hike, with Annie McMahon")).toBeInTheDocument();
     expect(screen.getByText("Bring water and snacks.")).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: partyExp })).toBeInTheDocument();
   });
 
   it("renders the AllTrails link with the correct href", () => {
@@ -28,16 +36,20 @@ describe("HikePost", () => {
   describe("functional", () => {
     it("does not throw when onClick is not provided", async () => {
       render(<HikePost hikeInfo={MOCK_HIKE_INFO}/>);
-      const button = screen.getByRole("button", { name: /join hike/i });
-      await userEvent.click(button);
+      const button1 = screen.getByRole("button", { name: /join hike/i });
+      const button2 = screen.getByRole("button", { name: partyExp });
+      await userEvent.click(button1);
+      await userEvent.click(button2);
     });
 
     it("calls onClick when the button is clicked", async () => {
       const onClickMock = jest.fn();
       render(<HikePost hikeInfo={MOCK_HIKE_INFO} onClick={onClickMock} />);
-      const button = screen.getByRole("button", { name: /join hike/i });
-      await userEvent.click(button);
-      expect(onClickMock).toHaveBeenCalledTimes(1);
+      const button1 = screen.getByRole("button", { name: /join hike/i });
+      const button2 = screen.getByRole("button", { name: partyExp });
+      await userEvent.click(button1);
+      await userEvent.click(button2);
+      expect(onClickMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/__tests__/other/Modal.test.js
+++ b/__tests__/other/Modal.test.js
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { useModal } from "@/app/context/ModalContext";
 import Modal from "@/app/Modal";
+import { MOCK_NAMES_AVATARS } from "@/app/lib/constants";
 
 jest.mock("@/app/context/ModalContext");
 
@@ -37,6 +38,29 @@ describe("Modal component", () => {
     render(<Modal />);
     expect(screen.getByText("Test Title")).toBeInTheDocument();
     expect(screen.getByText("Test Message")).toBeInTheDocument();
+    expect(screen.getByText("Close")).toBeInTheDocument();
+  });
+
+  it("renders modal rich content when modal is open and object is passed" +
+      "instead of a string", () => {
+    useModal.mockReturnValue({
+      modal: {
+        isOpen: true,
+        title: "Test Title",
+        message: MOCK_NAMES_AVATARS,
+        onConfirm: null,
+      },
+      closeModal: closeModalMock,
+    });
+    render(<Modal />);
+    const names = MOCK_NAMES_AVATARS.names;
+    const paths = MOCK_NAMES_AVATARS.paths;
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    names.map(uname => expect(screen.getByText(uname)).toBeInTheDocument());
+    paths.map((path, index) => {
+      const avatar = screen.getByRole('img', { name: names[index] });
+      expect(avatar).toHaveAttribute('src', path);
+    });
     expect(screen.getByText("Close")).toBeInTheDocument();
   });
 

--- a/app/Modal.jsx
+++ b/app/Modal.jsx
@@ -1,16 +1,63 @@
 "use client";
 import { useModal } from "@/app/context/ModalContext";
 
+/**
+ * 
+ * @param {object} namesAndPathsObj Contains 2 members:
+ *  1) key "names" and value being an array of user name strings;
+ *  2) key "paths" and value being an array of strings each representing a URL
+ *      path to an avatar image.
+ *  A participant/user is represented by a name & avatar path of equal index.
+ * @returns DIV parent of a CSS Grid, with even children wrapping avatar image
+ *  elements and odd children wrapping corresponding user names.
+ */
+const participantsGrid = (namesAndPathsObj) => {
+  const { names, paths } = namesAndPathsObj;
+  const d = (dividend, divisor) => (dividend - dividend % divisor) / divisor;
+  const pathCol = (x) => {
+    return (
+      <div key={x}>
+        <img src={paths[d(x, 2)]} alt={names[d(x, 2)]} />
+      </div>
+    );
+  };
+  const nameCol = (x) => {
+    return (
+      <div key={x}>
+        <p>{names[d(x, 2)]}</p>
+      </div>
+    );
+  };
+  const partyList = Array.from({length: 2 * names.length}, (value, index) => {
+    return index % 2 && nameCol(index) || pathCol(index);
+  });
+  return <div className="party-grid">{partyList}</div>;
+};
+
 export default function Modal() {
   const { modal, closeModal } = useModal();
 
   if (!modal.isOpen) return null;
 
+  /* The modal.message can be either a string or jsx wrapping user names and
+   * avatar urls. Modify final case's message value or chain more conditions
+   * for different modal content data in future features.
+   */
+  let message;
+
+  if (typeof modal.message === "string") {
+    message = <p>{modal.message}</p>;
+  } else if (Object.keys(modal.message ?? {}).join() === "names,paths") {
+    message = participantsGrid(modal.message);
+  } else {
+    message = (<></>);
+  }
+
   return (
     <div className="modal-overlay">
       <div className="modal-content">
         <h2>{modal.title}</h2>
-        <p>{modal.message}</p>
+        {message}
         {modal.onConfirm && (
           <button onClick={modal.onConfirm}>Confirm</button>
         )}

--- a/app/global.css
+++ b/app/global.css
@@ -112,6 +112,38 @@ button .add-trail-button {
   float: right;
 }
 
+/* Participant list buttons */
+.party-list {
+  background: none;
+  color: black;
+  margin: 0;
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.5rem 0.2rem;
+  border: none;
+  border-radius: 0;
+}
+
+/* Arrangement of data on participation modal.
+ * Height limit and scroll style applied here
+ * rather than to parent modal so that modal
+ * title can't be scrolled out of view and users
+ * need not scroll down to find close button.
+ */
+.party-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  max-height: 10rem;
+  overflow: scroll;
+}
+.party-grid img {
+  width: 3rem;
+  padding-top: 1rem;
+}
+.party-grid p {
+  padding-top: 1rem;
+}
+
 
 
 /*Hike section buttons */

--- a/app/lib/constants.js
+++ b/app/lib/constants.js
@@ -145,5 +145,28 @@ export const MOCK_USER = {
   bio: "Hello everyone!"
 };
 
+export const MOCK_PARTY_MBR = {
+  id: 3,
+  email: "someone@example.com",
+  user_name: "Nick",
+  avatar: "/newUser.png",
+  bio: "Hi everybody"
+};
 
+export const MOCK_PARTY_TBL = [
+  {
+    hike_id: 5,
+    user_id: 2,
+    id: 1
+  },
+  {
+    hike_id: 5,
+    user_id: 3,
+    id: 2
+  }
+];
 
+export const MOCK_NAMES_AVATARS = {
+  names: [ "Test User", "Nick" ],
+  paths: [ "/newUser.png", "/newUser.png" ]
+};

--- a/app/ui/components/HikePost.jsx
+++ b/app/ui/components/HikePost.jsx
@@ -24,6 +24,14 @@ export default function hikePost({
         {trail.difficulty_rating} * {trail.length} mi * {trail.elevation_gain}{" "}
         ft * {trail.route_type}
       </p>
+      <button
+        className="party-list"
+        name={hikeInfo.id}
+        value="participant"
+        onClick={handleClick}
+      >
+        {hikeInfo.participantsMessage}
+      </button>
       <p>{hikeInfo.comments}</p>
       <a href={trail.trail_link} target="_blank">
         AllTrails Link


### PR DESCRIPTION
## View a list of participants for each posted hike #1

* View no. participants per hike post on bio and join pages
* Click on the number of participants to pop a scrollable modal
* Modal shows name and avatar of each participant

### `HikeComponent.jsx`
The `useModal` is imported from `ModalContext` to provide `showModal` and `closeModal`.  The `fetchParticipantsByHike`  async function is imported from the API data script. An `async` function named `fetchParticipantsData` is written into the `<HikeComponent\>` export, and uses `fetchParticipantsByHike` to obtain the table of participants. The table of participants is mapped to an array of `user_id` values, the length of which is written into a message to label the button that will pop up the modal. The `fetchUserById` is run with `user_id`s from the table of participants to obtain the participants' **names** and their avatar image file **paths**. The function concludes with calling `setHikeDisplay` to append the participant count button label as a property `participantsMessage` and an object `listOfParticipants` holding an array of participant `names` and an array of participant avatar image `paths`. The `fetchParticipantsData` is called within `useEffect` to add the participants button label and arrays of names and file paths to the `hikeDisplay` state. A case is added to the click handler to run `showModal` with the `listOfParticipants` as the `message` param in the event that a button with a `value` attribute of `"participant"` is clicked.

### `HikePost.jsx`
A button element with `value="participant"` and `onClick` set to the click handler defined in the `HikeComponent` source is added to the render method's `JSX`. This button's child is the `participantsMessage` from the `HikeInfo` prop (sourced from the `hikeDisplay` state of `HikeComponent`). The button is styled with class `"party-list"`.

### `global.css`
The class `party-list` is defined to style the button showing the number of participants for the purpose of making it borderless for blending in with the hike information above and below it.  The class `party-grid` is defined to arrange the avatar image and name of each participant with CSS Grid Layout, and the view of this grid will be scrollable.

### `Modal.jsx`
A conditional is added to the render export that allows either plain text strings or JSX to be accepted as the `message` parameter of the `showModal` method defined in `ModalContext.js`. A helper function is written lexically above the render export that distributes names and avatar paths into the children of a DIV element styled with `party-grid`. The names and avatars should come from a `listOfParticipants` object as described in the above notes for additions to `HikeComponent.jsx`. **The added flexibility for the modal message will hopefully make it easier to add future modal features.** The CSS class `"party-list"` is assigned to the participants grid container as opposed to the entire `modal-content`-class container so that the modal title can't be scrolled out of view and so that users need not scroll down to find close button.

### `constants.js`
For unit tests, a second mock user's data object, a mock supabase-fetched table of participants, and a mock `listOfParticipants` (as if appended to `hikeDisplay` state by `fetchParticipantsData`) are added. 

### `HikeComponent.test.jsx` 
The mock participant data, `fetchParticipantsByHike`, and `useModal` are added here for testing the creation of a button and that `showModal` is run when the button is clicked. The `useModal` and `fetchParticipantsByHike` are given mock return values. It is taken into consideration that `fetchUserById` is called more than once due to the fetching of participant data. 

### `HikePost.test.jsx`
Using the import of a mock table of participants, expectation of a button in the document labeled with the number of participants is added to callback of the test case with the parameter `"renders the hike info correctly"`. For the description of `onClick` behavior, the additional get-element and associated event are added for the participants button.

### `Modal.test.js`
An additional test case is written for the modal receiving arrays of strings (user names and avatar image paths) instead of a single string, with corresponding expectations for the text and images in the participants grid.